### PR TITLE
Use latest version of cosign in apko-snapshot

### DIFF
--- a/apko-snapshot/action.yaml
+++ b/apko-snapshot/action.yaml
@@ -121,8 +121,6 @@ runs:
   steps:
     - name: Setup cosign
       uses: sigstore/cosign-installer@main
-      with:
-        cosign-release: v1.9.0
 
     - uses: imjasonh/setup-crane@v0.1
 


### PR DESCRIPTION
Signatures with older versions of cosign causing this output in `cosign verify`:
```
tuf: warning using deprecated ecdsa hex-encoded keys
tuf: warning using deprecated ecdsa hex-encoded keys
tuf: warning using deprecated ecdsa hex-encoded keys
tuf: warning using deprecated ecdsa hex-encoded keys
tuf: warning using deprecated ecdsa hex-encoded keys
tuf: warning using deprecated ecdsa hex-encoded keys
...
```