### PR TITLE
Pin apko for image builds

### DIFF
--- a/apko-publish/action.yaml
+++ b/apko-publish/action.yaml
@@ -111,7 +111,7 @@ outputs:
 
 runs:
   using: docker
-  image: "docker://ghcr.io/chainguard-dev/apko:canary"
+  image: "docker://ghcr.io/chainguard-dev/apko@sha256:b4553a20baeae0cb57afebbe8e695820a463677dd3cb0bd9a8434551f1a33cdd"
   env:
     # Set up go-containerregistry's GitHub keychain.
     GITHUB_ACTOR: ${{ inputs.repository_owner }}


### PR DESCRIPTION
```
Jan 19 00:11:15.367 [INFO] [arch:x86_64] finished building filesystem in /tmp/apko-239103982/x86_64
Error: failed to build layer image for "arm64": open /tmp/apko-239103982/aarch64/bin/busybox: no such file or directory
2023/01/19 00:11:15 error during command execution: failed to build layer image for "arm64": open /tmp/apko-239103982/aarch64/bin/busybox: no such file or directory
```