### PR TITLE
Revert "Use latest apko image (from HEAD)"

### DIFF
--- a/apko-publish/action.yaml
+++ b/apko-publish/action.yaml
@@ -116,7 +116,7 @@ outputs:
 
 runs:
   using: docker
-  image: "docker://ghcr.io/wolfi-dev/apko:latest"
+  image: "docker://ghcr.io/chainguard-dev/apko@sha256:b4553a20baeae0cb57afebbe8e695820a463677dd3cb0bd9a8434551f1a33cdd"
   env:
     # Set up go-containerregistry's GitHub keychain.
     GITHUB_ACTOR: ${{ inputs.repository_owner }}
@@ -147,7 +147,7 @@ runs:
       tagSuffix="--tag-suffix=${{ inputs.tag-suffix }}"
 
       export DIGEST_FILE=$(mktemp)
-      /usr/bin/apko publish \
+      /ko-app/apko publish \
         ${{ inputs.use-docker-mediatypes && '--use-docker-mediatypes' }} \
         ${{ inputs.package-version-tag-stem && '--package-version-tag-stem' }} \
         '--debug' \


### PR DESCRIPTION
Reverts chainguard-images/actions#90

Errors reported with images using busybox, `find` cannot be found.  Sounds like scriptlets aren't working with latest apko changes.  We use scriptlets in wolfi for busybox and glibc.  Rolling back for now to finx images.