### PR TITLE
This stops passing "now" as the `SOURCE_DATE_EPOCH` to `apko`.

### DIFF
--- a/apko-snapshot/action.yaml
+++ b/apko-snapshot/action.yaml
@@ -225,7 +225,6 @@ runs:
       id: snapshot-date
       run: |
         echo ::set-output name=date::$(date -u +%Y%m%d)
-        echo ::set-output name=epoch::$(date -u +%s)
       shell: bash
 
     - name: Generate dynamic inputs for apko-publish
@@ -245,7 +244,6 @@ runs:
         tag: ${{ inputs.base-tag }}:${{ inputs.target-tag }}-${{ steps.snapshot-date.outputs.date }}
         image_refs: ${{ inputs.image_refs }}
         stage_tags: ${{ inputs.stage_tags }}
-        source-date-epoch: ${{ steps.snapshot-date.outputs.epoch }}
         use-docker-mediatypes: ${{ inputs.use-docker-mediatypes }}
         keyring-append: ${{ inputs.keyring-append }}
         repository-append: ${{ inputs.repository-append }}


### PR DESCRIPTION
We have made changes to `apko` to compute the "build date epoch" based on `MAX(installed packages builddate)`, which should make the image timestamp a reflection of the last time one of the packages contributing to the image changed.

This should result in significantly less nightly churn from image rebuilds where only the timestamp changes.