### PR TITLE
Remove unused flags on publish

### DIFF
--- a/apko-publish/action.yaml
+++ b/apko-publish/action.yaml
@@ -41,11 +41,6 @@ inputs:
       The value to pass to --image-refs.
     default: /tmp/apko.images
 
-  stage_tags:
-    description: |
-      The value to pass to --stage-tags.
-    default: ''
-
   keyring-append:
     description: |
       The value to pass to --keyring-append.
@@ -106,31 +101,6 @@ inputs:
     description: |
       If automount-src is found, create a copy at this location (inside container)
     default: /work
-
-  package-version-tag:
-    description: |
-      apko can tag the final image with the version of the corresponding apk package passed in here.
-    required: false
-    default: ''
-
-  package-version-tag-stem:
-    description: |
-      stem version tags.
-    type: boolean
-    required: false
-    default: false
-
-  package-version-tag-prefix:
-    description: |
-      prefix for version tag(s).
-    required: false
-    default: ''
-
-  tag-suffix:
-    description: |
-      Suffix to use with the package-version-tag feature, if any.
-    required: false
-    default: ''
 
   sbom-path:
     description: |
@@ -219,7 +189,7 @@ runs:
         ${{ inputs.use-docker-mediatypes && '--use-docker-mediatypes' }} \
         ${{ inputs.package-version-tag-stem && '--package-version-tag-stem' }} \
         '--debug' \
-        --image-refs="${{ inputs.image_refs }}" --stage-tags="${{ inputs.stage_tags }}" ${{ inputs.config }} ${{ inputs.tag }} $keys $repos $packages $archs $build_options $packageVersionTag $packageVersionTagPrefix $tagSuffix $sbomPath | tee ${DIGEST_FILE}
+        --image-refs="${{ inputs.image_refs }}" ${{ inputs.config }} ${{ inputs.tag }} $keys $repos $packages $archs $build_options $sbomPath | tee ${DIGEST_FILE}
       echo EXIT CODE: $?
       echo ::set-output name=digest::$(cat ${DIGEST_FILE})
       EOF

--- a/apko-snapshot/action.yaml
+++ b/apko-snapshot/action.yaml
@@ -89,29 +89,6 @@ inputs:
     required: false
     default: ''
 
-  package-version-tag:
-    description: |
-      apko can tag the final image with the version of the corresponding apk package passed in here.
-    required: false
-    default: ''
-
-  package-version-tag-stem:
-    description: |
-      stem version tags.
-    required: false
-
-  package-version-tag-prefix:
-    description: |
-      prefix for version tag(s).
-    required: false
-    default: ''
-
-  tag-suffix:
-    description: |
-      Suffix to use with the package-version-tag feature, if any.
-    required: false
-    default: ''
-
   sbom-attest:
     description: |
       Upload SBOMs as attestations.
@@ -147,11 +124,6 @@ inputs:
     description: |
       The value to pass to --image-refs.
     default: apko.images
-
-  stage_tags:
-    description: |
-      The value to pass to --stage-tags.
-    default: ''
 
   automount-src:
     description: |
@@ -246,7 +218,6 @@ runs:
         config: ${{ inputs.config }}
         tag: ${{ inputs.base-tag }}:${{ inputs.target-tag }}-${{ steps.snapshot-date.outputs.date }}
         image_refs: ${{ inputs.image_refs }}
-        stage_tags: ${{ inputs.stage_tags }}
         use-docker-mediatypes: ${{ inputs.use-docker-mediatypes }}
         keyring-append: ${{ inputs.keyring-append }}
         repository-append: ${{ inputs.repository-append }}
@@ -255,10 +226,6 @@ runs:
         debug: ${{ inputs.debug }}
         automount-src: ${{ inputs.automount-src }}
         automount-dest: ${{ inputs.automount-dest }}
-        package-version-tag: ${{ inputs.package-version-tag }}
-        package-version-tag-stem: ${{ inputs.package-version-tag-stem }}
-        package-version-tag-prefix: ${{ inputs.package-version-tag-prefix }}
-        tag-suffix: ${{ inputs.tag-suffix }}
         build-options: ${{ inputs.build-options }}
         sbom-path: ${{ steps.apko-publish-inputs.outputs.sbom-path }}
         generic-user: ${{ inputs.generic-user }}


### PR DESCRIPTION
Fixes #125

I haven't dug deeply into what these unused flags could have been used for. But nothing can use this action while they are still being set because apko will throw an error. So removing them should make some things work, even if other things need to stop setting values for these flags.