### PR TITLE
replace removed --debug flag with --log-level

### DIFF
--- a/apko-build/action.yaml
+++ b/apko-build/action.yaml
@@ -113,7 +113,7 @@ runs:
       fi
       /usr/bin/apko build \
         --vcs=${{ inputs.vcs-url }} \
-        ${{ inputs.debug && '--debug' }} \
+        ${{ inputs.debug && '--log-level debug' }} \
         ${{ inputs.config }} ${{ inputs.tag }} output.tar $keys $repos $packages $archs $build_options
       echo EXIT CODE: $?
       EOF

--- a/apko-publish/action.yaml
+++ b/apko-publish/action.yaml
@@ -172,7 +172,7 @@ runs:
       export DIGEST_FILE=$(mktemp)
       /usr/bin/apko publish \
         --vcs=${{ inputs.vcs-url }} \
-        '--debug' \
+        ${{ inputs.debug && '--log-level debug' }} \
         --image-refs="${{ inputs.image_refs }}" ${{ inputs.config }} ${{ inputs.tag }} $keys $repos $packages $archs $build_options $sbomPath | tee ${DIGEST_FILE}
       echo EXIT CODE: $?
       echo ::set-output name=digest::$(cat ${DIGEST_FILE})


### PR DESCRIPTION
The `--debug` flag was removed as part of https://github.com/chainguard-dev/apko/pull/1011. This PR updates the build and publish actions to leverage the new `--log-level` flag instead.

Fixes: https://github.com/chainguard-images/actions/issues/130