### PR TITLE
Allow to provide custom OCI annotations

### DIFF
--- a/apko-publish/action.yaml
+++ b/apko-publish/action.yaml
@@ -116,6 +116,12 @@ inputs:
     required: false
     default: ''
 
+  annotations:
+    description: |
+      Annotations to add to the image. Format: key1:value1,key2:value2.
+    required: false
+    default: ''
+
 outputs:
   digest:
     value: ${{ steps.docker-run.outputs.digest }}
@@ -161,6 +167,7 @@ runs:
       [ -n "${{ inputs.repository-append }}" ] && repos="-r ${{ inputs.repository-append }}"
       [ -n "${{ inputs.package-append }}" ] && packages="-p ${{ inputs.package-append }}"
       [ -n  "${{ inputs.archs }}" ] && archs="--arch ${{ inputs.archs }}"
+      [ -n  "${{ inputs.annotations }}" ] && annotations="--annotations ${{ inputs.annotations }}"
       build_options=""
       if [ -n "${{ inputs.build-options }}" ]; then
         opts="${{ inputs.build-options }}"
@@ -175,7 +182,7 @@ runs:
       /usr/bin/apko publish \
         --vcs=${{ inputs.vcs-url }} \
         ${{ inputs.debug && '--log-level debug' }} \
-        --image-refs="${{ inputs.image_refs }}" ${{ inputs.config }} ${{ inputs.tag }} $keys $repos $packages $archs $build_options $sbomPath | tee ${DIGEST_FILE}
+        --image-refs="${{ inputs.image_refs }}" ${{ inputs.config }} ${{ inputs.tag }} $keys $repos $packages $archs $annotations $build_options $sbomPath | tee ${DIGEST_FILE}
       echo EXIT CODE: $?
       EOF
       )"

--- a/apko-snapshot/action.yaml
+++ b/apko-snapshot/action.yaml
@@ -130,6 +130,12 @@ inputs:
       In subsequent steps, if automount-src is found, create a copy at this location (inside container)
     default: /work
 
+  annotations:
+    description: |
+      Annotations to add to the final image. Format: key1:value1,key2:value2.
+    required: false
+    default: ''
+
   FULCIO_URL:
     required: false
     description: address of sigstore PKI server (default "https://fulcio.sigstore.dev")
@@ -224,6 +230,7 @@ runs:
         sbom-path: ${{ steps.apko-publish-inputs.outputs.sbom-path }}
         generic-user: ${{ inputs.generic-user }}
         generic-pass: ${{ inputs.generic-pass }}
+        annotations: ${{ inputs.annotations }}
 
     - uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
       with:

--- a/apko-snapshot/action.yaml
+++ b/apko-snapshot/action.yaml
@@ -130,6 +130,11 @@ inputs:
       In subsequent steps, if automount-src is found, create a copy at this location (inside container)
     default: /work
 
+  source-date-epoch:
+    description: |
+      The UNIX timestamp to use as the source date when building an image.
+    default: ''
+
   annotations:
     description: |
       Annotations to add to the final image. Format: key1:value1,key2:value2.
@@ -231,6 +236,7 @@ runs:
         generic-user: ${{ inputs.generic-user }}
         generic-pass: ${{ inputs.generic-pass }}
         annotations: ${{ inputs.annotations }}
+        source-date-epoch: ${{ inputs.source-date-epoch }}
 
     - uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
       with:


### PR DESCRIPTION
Hey 👋🏻

## Description

This pull request basically allows to provide custom OCI annotations to be added to the final artifacts (using either `apko-publish` or `apko-snapshot` actions).

If we want to add annotations without these changes, we likely need to use a separate action to update the config file before calling `apko-publish` (or `apko-snapshot`) (see [example](https://github.com/hpedrorodrigues/images/blob/e692419f263697f3ae97418ded436ffc391d660e/.github/workflows/publish.yml#L35-L43)) or implement some other workaround. The main idea here is to make this process easier.

## Basic Testing

- `apko-publish`: this version worked well [here](https://github.com/hpedrorodrigues/images/blob/06e805cea68b238bde5c297ecaf4436219b80d2c/.github/workflows/publish.yml#L41-L47) (see [job](https://github.com/hpedrorodrigues/images/actions/runs/8305257268/job/22731918240), for instance).

<details>
<summary>example manifest</summary>

`revision`, `created`, and `version` are the annotations we are interested in.

```bash
♪ crane manifest ghcr.io/hpedrorodrigues/envsubst:1.30.1 | jq
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "size": 916,
      "digest": "sha256:661b18f68e995e9171e1a60e0836a9ebbcc0344f299057e80c29b8efc7520df3",
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "size": 916,
      "digest": "sha256:55deeb9f2a1193a5caa3c3d254f13e93e535974a50af5bc1e04f66fb1ace4a1b",
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    }
  ],
  "annotations": {
    "org.opencontainers.image.authors": "Pedro Rodrigues <github.com/hpedrorodrigues>",
    "org.opencontainers.image.created": "2024-03-16T04:14:31",
    "org.opencontainers.image.description": "Simple image wrapping envsubst (gettext)",
    "org.opencontainers.image.revision": "06e805cea68b238bde5c297ecaf4436219b80d2c",
    "org.opencontainers.image.source": "https://github.com/hpedrorodrigues/images/tree/main/envsubst",
    "org.opencontainers.image.title": "envsubst",
    "org.opencontainers.image.version": "1.30.1"
  }
}
```
</details>

- `apko-snapshot`: this version is working well [here](https://github.com/hpedrorodrigues/images/blob/0323e2823c65c2de01ece9a9acbe7c1db14609fd/.github/workflows/publish.yml#L83-L95) (see [job](https://github.com/hpedrorodrigues/images/actions/runs/8317851904/job/22759096410), for instance).

<details>
<summary>example manifest</summary>

`revision`, `created`, and `version` are the annotations we are interested in.

```bash
♪ crane manifest ghcr.io/hpedrorodrigues/envsubst:1.47.1 | jq
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "size": 916,
      "digest": "sha256:204151eafbcf0ef6ed1b9b06638f58c82d6567b65f04f947f6eb7f4d3e1f074e",
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "size": 916,
      "digest": "sha256:7346a405e766c3ba82cbf53e4635b4696c5643da3bc2c4529a1fda33e2f8e61a",
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    }
  ],
  "annotations": {
    "org.opencontainers.image.authors": "Pedro Rodrigues <github.com/hpedrorodrigues>",
    "org.opencontainers.image.created": "2024-03-17T19:44:53",
    "org.opencontainers.image.description": "Simple image wrapping envsubst (gettext)",
    "org.opencontainers.image.revision": "d9d40e00117119c1990afdadfe47fa2dd88f1756",
    "org.opencontainers.image.source": "https://github.com/hpedrorodrigues/images/tree/main/envsubst",
    "org.opencontainers.image.title": "envsubst",
    "org.opencontainers.image.version": "1.47.1"
  }
}
```
</details>

---

Let me know if these changes make sense for this project or if you have any concerns.