### PR TITLE
fix docker/login-action node.js deprecation warning

### DIFF
--- a/apko-snapshot/action.yaml
+++ b/apko-snapshot/action.yaml
@@ -225,7 +225,7 @@ runs:
         generic-user: ${{ inputs.generic-user }}
         generic-pass: ${{ inputs.generic-pass }}
 
-    - uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
+    - uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
       with:
         registry: ${{ inputs.registry }}
         username: ${{ inputs.username }}


### PR DESCRIPTION
- update to docker/login-action v3.3.0

```
The following actions uses Node.js version which is deprecated and will be forced to run on node20: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```