### PR TITLE
fix docker/setup-qemu-action node.js deprecation warning

### DIFF
--- a/apko-snapshot/action.yaml
+++ b/apko-snapshot/action.yaml
@@ -189,7 +189,7 @@ runs:
     - uses: imjasonh/setup-crane@v0.3
 
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
+      uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
 
     - name: Generate snapshot date
       id: snapshot-date


### PR DESCRIPTION
- update docker/setup-qemu-action to v3.2.0

```
The following actions uses Node.js version which is deprecated and will be forced to run on node20: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```