### PR TITLE
fix set-output deprecation messages in scan-apk

### DIFF
--- a/scan-apk/action.yaml
+++ b/scan-apk/action.yaml
@@ -58,7 +58,7 @@ runs:
         - ${{ inputs.architecture }}
         EOF
 
-        echo "::set-output name=config-file::${TMP}"
+        echo "config-file=${TMP}" >> $GITHUB_OUTPUT
 
     - shell: bash
       run: |
@@ -79,4 +79,4 @@ runs:
     - id: scan-report
       shell: bash
       run: |
-        echo "::set-output name=vuln-count::$(cat ${{ steps.grype-scan.outputs.sarif }} | jq '.runs[0].results | length')"
+        echo "vuln-count=$(cat ${{ steps.grype-scan.outputs.sarif }} | jq '.runs[0].results | length')" >> $GITHUB_OUTPUT


### PR DESCRIPTION
- kudos to @andros21 for the fix in chainguard-images#127
- isolate commit

```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. 
For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```