### PR TITLE
fix set-output deprecation messages in release-monitoring

### DIFF
--- a/release-monitoring/action.yaml
+++ b/release-monitoring/action.yaml
@@ -50,6 +50,6 @@ runs:
         echo "Response:"
         echo "--------"
         cat "${TMP}"
-        echo "::set-output name=latest-version::$(cat "${TMP}" | jq -r .latest_version)"
-        echo "::set-output name=stable-versions::$(cat "${TMP}" | jq -r '.stable_versions | join(",")')"
-        echo "::set-output name=all-versions::$(cat "${TMP}" | jq -r '.versions | join(",")')"
+        echo "latest-version=$(cat "${TMP}" | jq -r .latest_version)" >> $GITHUB_OUTPUT
+        echo "stable-versions=$(cat "${TMP}" | jq -r '.stable_versions | join(",")')" >> $GITHUB_OUTPUT
+        echo "all-versions=$(cat "${TMP}" | jq -r '.versions | join(",")')" >> $GITHUB_OUTPUT


### PR DESCRIPTION
- kudos to @andros21 for the fix in chainguard-images#127
- isolate commit

```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. 
For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```