### PR TITLE
fix set-output deprecation messages in vul-scans

### DIFF
--- a/vul-scans/action.yaml
+++ b/vul-scans/action.yaml
@@ -109,7 +109,7 @@ runs:
 
     - id: scan-start
       run: |
-        echo ::set-output name=date::$(TZ=Zulu date "+%Y-%m-%dT%H:%M:%SZ")
+        echo "date=$(TZ=Zulu date "+%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
       shell: bash
 
     - id: install-snyk
@@ -321,9 +321,9 @@ runs:
 
         echo "SNYK_COUNT: $SNYK_COUNT, GRYPE_COUNT: $GRYPE_COUNT, TRIVY_COUNT: $TRIVY_COUNT"
 
-        echo "::set-output name=SNYK_COUNT::$SNYK_COUNT"
-        echo "::set-output name=GRYPE_COUNT::$GRYPE_COUNT"
-        echo "::set-output name=TRIVY_COUNT::$TRIVY_COUNT"
+        echo "SNYK_COUNT=$SNYK_COUNT" >> $GITHUB_OUTPUT
+        echo "GRYPE_COUNT=$GRYPE_COUNT" >> $GITHUB_OUTPUT
+        echo "TRIVY_COUNT=$TRIVY_COUNT" >> $GITHUB_OUTPUT
 
     - name: Cue Verify Attestation
       id: cue-verify


### PR DESCRIPTION
- kudos to @andros21 for the fix in chainguard-images#127
- isolate commit

```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. 
For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```