### PR TITLE
Add support to set repositories for pulling packages at build time

### DIFF
--- a/apko-build/action.yaml
+++ b/apko-build/action.yaml
@@ -30,6 +30,12 @@ inputs:
       The value to pass to --keyring-append.
     default: ''
 
+  build-repository-append:
+    description: |
+      The value to pass to --build-repository-append.
+    required: false
+    default: ''
+
   repository-append:
     description: |
       The value to pass to --repository-append.
@@ -107,6 +113,7 @@ runs:
       fi
       [ -n "${{ inputs.source-date-epoch }}" ] && export SOURCE_DATE_EPOCH='${{ inputs.source-date-epoch }}'
       [ -n "${{ inputs.keyring-append }}" ] && keys="-k ${{ inputs.keyring-append }}"
+      [ -n "${{ inputs.build-repository-append }}" ] && build_repos="-b ${{ inputs.build-repository-append }}"
       [ -n "${{ inputs.repository-append }}" ] && repos="-r ${{ inputs.repository-append }}"
       [ -n "${{ inputs.package-append }}" ] && packages="-p ${{ inputs.package-append }}"
       [ -n "${{ inputs.archs }}" ] && archs="--arch ${{ inputs.archs }}"
@@ -121,7 +128,7 @@ runs:
         --vcs=${{ inputs.vcs-url }} \
         --lockfile=${{ inputs.lockfile }} \
         ${{ inputs.debug && '--log-level debug' }} \
-        ${{ inputs.config }} ${{ inputs.tag }} output.tar $keys $repos $packages $archs $build_options
+        ${{ inputs.config }} ${{ inputs.tag }} output.tar $keys $build_repos $repos $packages $archs $build_options
       echo EXIT CODE: $?
       EOF
       )"

--- a/apko-publish/action.yaml
+++ b/apko-publish/action.yaml
@@ -54,6 +54,12 @@ inputs:
       The value to pass to --keyring-append.
     default: ''
 
+  build-repository-append:
+    description: |
+      The value to pass to --build-repository-append.
+    required: false
+    default: ''
+
   repository-append:
     description: |
       The value to pass to --repository-append.
@@ -170,6 +176,7 @@ runs:
       fi
       [ -n "${{ inputs.source-date-epoch }}" ] && export SOURCE_DATE_EPOCH='${{ inputs.source-date-epoch }}'
       [ -n "${{ inputs.keyring-append }}" ] && keys="-k ${{ inputs.keyring-append }}"
+      [ -n "${{ inputs.build-repository-append }}" ] && build_repos="-b ${{ inputs.build-repository-append }}"
       [ -n "${{ inputs.repository-append }}" ] && repos="-r ${{ inputs.repository-append }}"
       [ -n "${{ inputs.package-append }}" ] && packages="-p ${{ inputs.package-append }}"
       [ -n  "${{ inputs.archs }}" ] && archs="--arch ${{ inputs.archs }}"
@@ -189,7 +196,7 @@ runs:
         --vcs=${{ inputs.vcs-url }} \
         --lockfile=${{ inputs.lockfile }} \
         ${{ inputs.debug && '--log-level debug' }} \
-        --image-refs="${{ inputs.image_refs }}" ${{ inputs.config }} ${{ inputs.tag }} $keys $repos $packages $archs $annotations $build_options $sbomPath | tee ${DIGEST_FILE}
+        --image-refs="${{ inputs.image_refs }}" ${{ inputs.config }} ${{ inputs.tag }} $keys $build_repos $repos $packages $archs $annotations $build_options $sbomPath | tee ${DIGEST_FILE}
       echo EXIT CODE: $?
       EOF
       )"

--- a/apko-snapshot/action.yaml
+++ b/apko-snapshot/action.yaml
@@ -62,6 +62,12 @@ inputs:
     required: false
     default: ''
 
+  build-repository-append:
+    description: |
+      The value to pass to --build-repository-append.
+    required: false
+    default: ''
+
   repository-append:
     description: |
       The value to pass to --repository-append.
@@ -232,6 +238,7 @@ runs:
         tag: ${{ inputs.base-tag }}:${{ inputs.target-tag }}-${{ steps.snapshot-date.outputs.date }}
         image_refs: ${{ inputs.image_refs }}
         keyring-append: ${{ inputs.keyring-append }}
+        build-repository-append: ${{ inputs.build-repository-append }}
         repository-append: ${{ inputs.repository-append }}
         package-append: ${{ inputs.package-append }}
         archs: ${{ inputs.archs }}


### PR DESCRIPTION
Hey 👋🏻 

## Description

The distinction between build-time and runtime repositories was introduced in `apko` a few months ago (see [v0.15.0](https://github.com/chainguard-dev/apko/releases/tag/v0.15.0)).

This pull request basically allows us to set build-time repositories in `apko-build`, `apko-publish`, and `apko-snapshot` actions.

## Reference

For more details, please see:
- https://github.com/chainguard-dev/apko/pull/1169
- https://github.com/chainguard-dev/apko/issues/1107